### PR TITLE
Add terraform s3 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### VS Code ###
+.vscode/

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  backend "s3" {
+    bucket = "fryrank-terraform-state-bucket"
+    key    = "s3/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+provider "aws" {
+  region = local.region
+}
+
+locals {
+  region      = "us-west-2"
+  bucket_name = "fryrank-terraform-state-bucket"
+}
+
+module "fryrank-terraform-state-bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.6.0"
+
+  bucket = local.bucket_name
+
+  versioning = {
+    status     = true
+    mfa_delete = false
+  }
+}

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -1,0 +1,14 @@
+output "s3_bucket_id" {
+  description = "The name of the bucket."
+  value       = module.fryrank-terraform-state-bucket.s3_bucket_id
+}
+
+output "s3_bucket_arn" {
+  description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
+  value       = module.fryrank-terraform-state-bucket.s3_bucket_arn
+}
+
+output "s3_bucket_region" {
+  description = "The AWS region this bucket resides in."
+  value       = module.fryrank-terraform-state-bucket.s3_bucket_region
+}

--- a/s3/versions.tf
+++ b/s3/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.61"
+    }
+  }
+}


### PR DESCRIPTION
This commit adds in terraform s3 module to create a terraform.tfstate bucket to hold all of our terraform state files for our future modules. This is needed in order to track infrstructure changes across machines. We use a s3 bucket because terraform states store sensitive data that would not live well in version control.