### PR TITLE
Add tf state tracking to ECR subdir

### DIFF
--- a/ecr/main.tf
+++ b/ecr/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "fryrank-terraform-state-bucket"
+    key    = "ecr/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
 provider "aws" {
   region = local.region
 }


### PR DESCRIPTION
We add tf state tracking to the ECR subdirectory to be able to trace history and current status of the ECR infrastructure using terraform from different machines